### PR TITLE
✨ Feature: 이메일 인증 성공 후 인증번호 Redis에서 삭제 처리

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/implement/VerificationCodeService.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/implement/VerificationCodeService.java
@@ -3,6 +3,8 @@ package zzangdol.moodoodleapi.member.implement;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import zzangdol.moodoodlecommon.exception.custom.VerificationCodeException;
+import zzangdol.moodoodlecommon.response.status.ErrorStatus;
 import zzangdol.redis.dao.VerificationCodeRepository;
 import zzangdol.redis.domain.VerificationCode;
 
@@ -29,7 +31,18 @@ public class VerificationCodeService {
 
     public boolean verifyCode(String id, String code) {
         VerificationCode storedCode = verificationCodeRepository.findById(id).orElse(null);
-        return storedCode != null && storedCode.getCode().equals(code);
+        if (storedCode == null) {
+            throw new VerificationCodeException(ErrorStatus.VERIFICATION_CODE_EXPIRED);
+        }
+        if (!storedCode.getCode().equals(code)) {
+            throw new VerificationCodeException(ErrorStatus.INVALID_VERIFICATION_CODE);
+        }
+        deleteVerificationCode(id);
+        return true;
+    }
+
+    private void deleteVerificationCode(String id) {
+        verificationCodeRepository.deleteById(id);
     }
 
 }

--- a/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/exception/custom/VerificationCodeException.java
+++ b/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/exception/custom/VerificationCodeException.java
@@ -1,2 +1,12 @@
-package zzangdol.moodoodlecommon.exception.custom;public class VerificationCodeException {
+package zzangdol.moodoodlecommon.exception.custom;
+
+import zzangdol.moodoodlecommon.exception.GeneralException;
+import zzangdol.moodoodlecommon.response.status.ErrorStatus;
+
+public class VerificationCodeException extends GeneralException {
+
+    public VerificationCodeException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+
 }

--- a/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/response/status/ErrorStatus.java
+++ b/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/response/status/ErrorStatus.java
@@ -11,7 +11,12 @@ public enum ErrorStatus implements BaseStatus {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 에러, 담당자에게 문의 바랍니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 4000, "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4001, "로그인이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, 4002, "금지된 요청입니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, 4002, "금지된 요청입니다."),
+
+    // Auth (4050 ~ 4051)
+    VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, 4050, "인증 코드가 만료되었습니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 4051, "잘못된 인증 코드입니다.");
+
 
     private final HttpStatus httpStatus;
     private final int code;


### PR DESCRIPTION
## 🔎 Description
> 이메일 인증 성공 후 인증번호를 Redis에서 삭제하도록 처리했습니다.
추가로, 인증번호가 만료된 경우와 일치하지 않는 경우 예외가 발생하도록 처리했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/22](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/22)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
