### PR TITLE
🐞 BugFix: Redis 설정 시 CONFIG 명령어 실행 문제 해결

### DIFF
--- a/moodoodle-infrastructure/src/main/java/zzangdol/redis/config/RedisConfig.java
+++ b/moodoodle-infrastructure/src/main/java/zzangdol/redis/config/RedisConfig.java
@@ -1,18 +1,21 @@
 package zzangdol.redis.config;
 
-import static org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import zzangdol.InfrastructurePackageLocation;
 
-@EnableRedisRepositories(basePackageClasses = InfrastructurePackageLocation.class, enableKeyspaceEvents = ON_STARTUP)
+@EnableRedisRepositories(
+        basePackageClasses = InfrastructurePackageLocation.class,
+        enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
+        keyspaceNotificationsConfigParameter = ""
+)
 @Configuration
 public class RedisConfig {
 


### PR DESCRIPTION
## 🔎 Description
> Spring Data Redis의 키스페이스 이벤트 알림을 설정하는 과정에서 애플리케이션이 예외를 발생시키는 것으로 추측하여 @EnableRedisRepositories 어노테이션에 keyspaceNotificationsConfigParameter 매개변수를 빈 문자열로 설정하여 CONFIG 명령어 실행 시도를 방지했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/24](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/24)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
