### PR TITLE
:sparkles: Feature: 이메일 검증 성공 후 토큰 발급 로직 구현

### DIFF
--- a/moodoodle-api/build.gradle
+++ b/moodoodle-api/build.gradle
@@ -17,6 +17,14 @@ dependencies {
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // auth
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('bootJar') {

--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/config/SecurityConfig.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package zzangdol.moodoodleapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(
+                        (authorizeRequests) -> authorizeRequests
+                                .requestMatchers(
+                                        "/",
+                                        "/health-check/**",
+                                        "/api/**"
+                                ).permitAll()
+                )
+                .build();
+    }
+
+}

--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/business/MemberFacade.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/business/MemberFacade.java
@@ -2,6 +2,7 @@ package zzangdol.moodoodleapi.member.business;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import zzangdol.moodoodleapi.member.implement.EmailVerificationTokenService;
 import zzangdol.moodoodleapi.member.implement.VerificationCodeService;
 import zzangdol.moodoodleapi.member.presentation.dto.EmailVerificationRequest;
 import zzangdol.ses.service.AwsSesService;
@@ -10,15 +11,17 @@ import zzangdol.ses.service.AwsSesService;
 @RequiredArgsConstructor
 public class MemberFacade {
 
-    private final VerificationCodeService verificationCodeService;
     private final AwsSesService awsSesService;
+    private final VerificationCodeService verificationCodeService;
+    private final EmailVerificationTokenService emailVerificationTokenService;
 
     public boolean sendVerificationEmail(String email) {
         String verificationCode = verificationCodeService.generateAndSaveCode(email);
         return awsSesService.sendVerificationEmail(email, verificationCode);
     }
 
-    public boolean verifyEmail(EmailVerificationRequest request) {
-        return verificationCodeService.verifyCode(request.getEmail(), request.getCode());
+    public String verifyEmail(EmailVerificationRequest request) {
+        verificationCodeService.verifyCode(request.getEmail(), request.getCode());
+        return emailVerificationTokenService.generateAndSaveCode(request.getEmail());
     }
 }

--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/implement/EmailVerificationTokenService.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/implement/EmailVerificationTokenService.java
@@ -1,0 +1,53 @@
+package zzangdol.moodoodleapi.member.implement;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import zzangdol.moodoodlecommon.exception.custom.EmailVerificationTokenException;
+import zzangdol.moodoodlecommon.response.status.ErrorStatus;
+import zzangdol.redis.dao.EmailVerificationTokenRepository;
+import zzangdol.redis.domain.EmailVerificationToken;
+
+@RequiredArgsConstructor
+@Service
+public class EmailVerificationTokenService {
+
+    private final EmailVerificationTokenRepository emailVerificationTokenRepository;
+
+    public String generateAndSaveCode(String id) {
+        String token = generateSecureToken();
+        saveEmailVerificationToken(id, token, 86400L);
+        return token;
+    }
+
+    private String generateSecureToken() {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[24]; // 192 bits
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    public void saveEmailVerificationToken(String id, String token, Long ttl) {
+        EmailVerificationToken emailVerificationToken = EmailVerificationToken.builder()
+                .id(id)
+                .token(token)
+                .ttl(ttl)
+                .build();
+        emailVerificationTokenRepository.save(emailVerificationToken);
+    }
+
+    public boolean verifyToken(String id, String token) {
+        EmailVerificationToken storedToken = emailVerificationTokenRepository.findById(id).orElse(null);
+        if (storedToken == null || !storedToken.getToken().equals(token)) {
+            throw new EmailVerificationTokenException(ErrorStatus.INVALID_EMAIL_VERIFICATION_TOKEN);
+        }
+        deleteEmailVerificationToken(id);
+        return true;
+    }
+
+    private void deleteEmailVerificationToken(String id) {
+        emailVerificationTokenRepository.deleteById(id);
+    }
+
+}

--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/presentation/MemberController.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/member/presentation/MemberController.java
@@ -11,7 +11,7 @@ import zzangdol.moodoodleapi.member.presentation.dto.EmailVerificationRequest;
 import zzangdol.moodoodlecommon.response.ApiResponse;
 
 @RequiredArgsConstructor
-@RequestMapping("/members")
+@RequestMapping("/api/members")
 @RestController
 public class MemberController {
 
@@ -23,7 +23,7 @@ public class MemberController {
     }
 
     @PostMapping("/verify-email")
-    public ApiResponse<Boolean> verifyEmail(@RequestBody EmailVerificationRequest request) {
+    public ApiResponse<String> verifyEmail(@RequestBody EmailVerificationRequest request) {
         return ApiResponse.onSuccess(memberFacade.verifyEmail(request));
     }
 

--- a/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/exception/custom/EmailVerificationTokenException.java
+++ b/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/exception/custom/EmailVerificationTokenException.java
@@ -1,0 +1,12 @@
+package zzangdol.moodoodlecommon.exception.custom;
+
+import zzangdol.moodoodlecommon.exception.GeneralException;
+import zzangdol.moodoodlecommon.response.status.ErrorStatus;
+
+public class EmailVerificationTokenException extends GeneralException {
+
+    public EmailVerificationTokenException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+
+}

--- a/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/response/status/ErrorStatus.java
+++ b/moodoodle-common/src/main/java/zzangdol/moodoodlecommon/response/status/ErrorStatus.java
@@ -15,7 +15,9 @@ public enum ErrorStatus implements BaseStatus {
 
     // Auth (4050 ~ 4051)
     VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, 4050, "인증 코드가 만료되었습니다."),
-    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 4051, "잘못된 인증 코드입니다.");
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 4051, "유효하지 않은 인증 코드입니다."),
+    INVALID_EMAIL_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, 4052, "유효하지 않은 이메일 인증 토큰입니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/moodoodle-infrastructure/src/main/java/zzangdol/redis/dao/EmailVerificationTokenRepository.java
+++ b/moodoodle-infrastructure/src/main/java/zzangdol/redis/dao/EmailVerificationTokenRepository.java
@@ -1,0 +1,9 @@
+package zzangdol.redis.dao;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import zzangdol.redis.domain.EmailVerificationToken;
+
+@Repository
+public interface EmailVerificationTokenRepository extends CrudRepository<EmailVerificationToken, String> {
+}

--- a/moodoodle-infrastructure/src/main/java/zzangdol/redis/domain/EmailVerificationToken.java
+++ b/moodoodle-infrastructure/src/main/java/zzangdol/redis/domain/EmailVerificationToken.java
@@ -1,0 +1,30 @@
+package zzangdol.redis.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value = "emailVerificationToken")
+public class EmailVerificationToken {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String token;
+
+    @TimeToLive
+    private Long ttl;
+
+    @Builder
+    public EmailVerificationToken(String id, String token, Long ttl) {
+        this.id = id;
+        this.token = token;
+        this.ttl = ttl;
+    }
+
+}


### PR DESCRIPTION
## 🔎 Description
> 이메일 검증이 성공하면 사용자에게 인증 성공 토큰을 발급하도록 구현했습니다.
Spring Security, JWT 관련 의존성을 추가했습니다.

## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/26](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/26)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
