### PR TITLE
⚙ Setting: 메모리 스왑 설정

### DIFF
--- a/.ebextensions-dev/01-setup-swap.config
+++ b/.ebextensions-dev/01-setup-swap.config
@@ -1,0 +1,8 @@
+commands:
+  01setup_swap:
+    test: test ! -e /var/swapfile
+    command: |
+      /bin/dd if=/dev/zero of=/var/swapfile bs=128M count=16
+      /bin/chmod 600 /var/swapfile
+      /sbin/mkswap /var/swapfile
+      /sbin/swapon /var/swapfile

--- a/.ebextensions-prod/01-setup-swap.config
+++ b/.ebextensions-prod/01-setup-swap.config
@@ -1,0 +1,8 @@
+commands:
+  01setup_swap:
+    test: test ! -e /var/swapfile
+    command: |
+      /bin/dd if=/dev/zero of=/var/swapfile bs=128M count=16
+      /bin/chmod 600 /var/swapfile
+      /sbin/mkswap /var/swapfile
+      /sbin/swapon /var/swapfile


### PR DESCRIPTION
## 🔎 Description
> EC2 메모리 부족 현상을 해결하기 위해 Elastic Beanstalk 구성 파일에 메모리 스왑을 설정했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/32](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/32)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
