### PR TITLE
🐞 BugFix: CORS 설정 allowedOriginPatterns으로 변경

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/moodoodleapi/global/config/SecurityConfig.java
+++ b/moodoodle-api/src/main/java/zzangdol/moodoodleapi/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package zzangdol.moodoodleapi.global.config;
 
 import java.util.Arrays;
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -60,8 +59,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Collections.singletonList("*")); // 모든 도메인에서의 접근을 허용합니다.
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type", "X-Email-Verification-Token"));
         configuration.setAllowCredentials(true);
 


### PR DESCRIPTION
## 🔎 Description
> ORS 설정의 allowedOrigins를 allowedOriginPatterns로 바꿔 모든 도메인에 대한 접근을 허용하는 패턴을 설정했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/45](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/45)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
