### PR TITLE
:sparkles: Feature: Scrap 생성 및 삭제 API 통일

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/scrap/business/ScrapFacade.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/business/ScrapFacade.java
@@ -13,8 +13,8 @@ public class ScrapFacade {
     private final ScrapCommandService scrapCommandService;
     private final ScrapQueryService scrapQueryService;
 
-    public Long createScrap(User user, Long diaryId) {
-        return scrapCommandService.createScrap(user, diaryId).getId();
+    public void handleScrap(User user, Long diaryId) {
+        scrapCommandService.handleScrap(user, diaryId);
     }
 
     public void addCategoryToScrap(User user, Long scrapId, Long categoryId) {

--- a/moodoodle-api/src/main/java/zzangdol/scrap/implement/ScrapCommandService.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/implement/ScrapCommandService.java
@@ -1,11 +1,10 @@
 package zzangdol.scrap.implement;
 
-import zzangdol.scrap.domain.Scrap;
 import zzangdol.user.domain.User;
 
 public interface ScrapCommandService {
 
-    Scrap createScrap(User user, Long diaryId);
+    void handleScrap(User user, Long diaryId);
 
     void addCategoryToScrap(User user, Long scrapId, Long categoryId);
 

--- a/moodoodle-api/src/main/java/zzangdol/scrap/implement/ScrapCommandServiceImpl.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/implement/ScrapCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package zzangdol.scrap.implement;
 
 import groovy.util.logging.Slf4j;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,7 +10,6 @@ import zzangdol.diary.dao.DiaryRepository;
 import zzangdol.diary.domain.Diary;
 import zzangdol.exception.custom.CategoryNotFoundException;
 import zzangdol.exception.custom.DiaryNotFoundException;
-import zzangdol.exception.custom.ScrapDuplicateException;
 import zzangdol.exception.custom.ScrapNotFoundException;
 import zzangdol.scrap.dao.CategoryRepository;
 import zzangdol.scrap.dao.ScrapRepository;
@@ -29,22 +29,19 @@ public class ScrapCommandServiceImpl implements ScrapCommandService {
     private final DiaryRepository diaryRepository;
 
     @Override
-    public Scrap createScrap(User user, Long diaryId) {
-        checkScrapDuplication(user, diaryId);
-        Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> DiaryNotFoundException.EXCEPTION);
-        Scrap scrap = buildScrap(user, diary);
+    public void handleScrap(User user, Long diaryId) {
+        Optional<Scrap> optionalScrap = scrapRepository.findScrapByUserAndDiaryId(user, diaryId);
+        if (optionalScrap.isPresent()) {
+            scrapRepository.delete(optionalScrap.get());
+        } else {
+            Diary diary = diaryRepository.findById(diaryId)
+                    .orElseThrow(() -> DiaryNotFoundException.EXCEPTION);
+            Scrap scrap = buildScrap(user, diary);
 
-        Category defaultCategory = categoryRepository.findCategoryByUserAndName(user, Constants.DEFAULT_CATEGORY_NAME)
-                .orElseThrow(() -> CategoryNotFoundException.EXCEPTION);
-        scrap = scrapRepository.save(scrap);
-        addCategoryToScrap(user, scrap.getId(), defaultCategory.getId());
-        return scrap;
-    }
-
-    private void checkScrapDuplication(User user, Long diaryId) {
-        if (scrapRepository.findScrapByUserAndDiaryId(user, diaryId).isPresent()) {
-            throw ScrapDuplicateException.EXCEPTION;
+            Category defaultCategory = categoryRepository.findCategoryByUserAndName(user, Constants.DEFAULT_CATEGORY_NAME)
+                    .orElseThrow(() -> CategoryNotFoundException.EXCEPTION);
+            scrap = scrapRepository.save(scrap);
+            addCategoryToScrap(user, scrap.getId(), defaultCategory.getId());
         }
     }
 
@@ -70,7 +67,7 @@ public class ScrapCommandServiceImpl implements ScrapCommandService {
     public void deleteScrap(User user, Long scrapId) {
         Scrap scrap = scrapRepository.findById(scrapId)
                 .orElseThrow(() -> ScrapNotFoundException.EXCEPTION);
-        scrapRepository.delete(scrap);
+
     }
 
     private ScrapCategory buildScrapCategory(Scrap scrap, Category category) {

--- a/moodoodle-api/src/main/java/zzangdol/scrap/presentation/ScrapController.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/presentation/ScrapController.java
@@ -33,12 +33,13 @@ public class ScrapController {
             ErrorStatus.DIARY_NOT_FOUND
     })
     @Operation(
-            summary = "스크랩 생성 🔑",
+            summary = "스크랩 생성 및 취소 🔑",
             description = "새로운 스크랩을 생성합니다."
     )
     @PostMapping
-    public ResponseDto<Long> createScrap(@AuthUser User user, @Valid @RequestParam("diaryId") Long diaryId) {
-        return ResponseDto.onSuccess(scrapFacade.createScrap(user, diaryId));
+    public ResponseDto<Void> handleScrap(@AuthUser User user, @Valid @RequestParam("diaryId") Long diaryId) {
+        scrapFacade.handleScrap(user, diaryId);
+        return ResponseDto.onSuccess();
     }
 
     @ApiErrorCodeExample({


### PR DESCRIPTION
## 🔎 Description
> 기존에 분리되어 있던 Scrap 생성 API와 삭제 API를 통일했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/83](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/83)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
