### PR TITLE
:recycle: Refactor: 회원 정보 수정 API 분리

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/user/business/UserFacade.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/business/UserFacade.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component;
 import zzangdol.user.implement.UserCommandService;
 import zzangdol.user.presentation.dto.request.PushNotificationRequest;
 import zzangdol.user.presentation.dto.request.UserInfoUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNicknameUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNotificationTimeUpdateRequest;
 import zzangdol.user.presentation.dto.response.UserInfoResponse;
 import zzangdol.user.domain.User;
 
@@ -20,6 +22,14 @@ public class UserFacade {
 
     public UserInfoResponse updateUserInfo(User user, UserInfoUpdateRequest request) {
         return UserMapper.toUserInfoResponse(userCommandService.updateUserInfo(user, request));
+    }
+
+    public UserInfoResponse updateUserNickname(User user, UserNicknameUpdateRequest request) {
+        return UserMapper.toUserInfoResponse(userCommandService.updateUserNickname(user, request));
+    }
+
+    public UserInfoResponse updateUserNotificationTime(User user, UserNotificationTimeUpdateRequest request) {
+        return UserMapper.toUserInfoResponse(userCommandService.updateUserNotificationTime(user, request));
     }
 
     public boolean withDrawUser(User user) {

--- a/moodoodle-api/src/main/java/zzangdol/user/implement/UserCommandService.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/implement/UserCommandService.java
@@ -3,10 +3,16 @@ package zzangdol.user.implement;
 import zzangdol.user.domain.User;
 import zzangdol.user.presentation.dto.request.PushNotificationRequest;
 import zzangdol.user.presentation.dto.request.UserInfoUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNicknameUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNotificationTimeUpdateRequest;
 
 public interface UserCommandService {
 
     User updateUserInfo(User user, UserInfoUpdateRequest request);
+
+    User updateUserNickname(User user, UserNicknameUpdateRequest request);
+
+    User updateUserNotificationTime(User user, UserNotificationTimeUpdateRequest request);
 
     User handlePushNotifications(User user, PushNotificationRequest request);
 

--- a/moodoodle-api/src/main/java/zzangdol/user/implement/UserCommandServiceImpl.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/implement/UserCommandServiceImpl.java
@@ -13,6 +13,8 @@ import zzangdol.user.dao.UserRepository;
 import zzangdol.user.domain.User;
 import zzangdol.user.presentation.dto.request.PushNotificationRequest;
 import zzangdol.user.presentation.dto.request.UserInfoUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNicknameUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNotificationTimeUpdateRequest;
 
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +30,18 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public User updateUserInfo(User user, UserInfoUpdateRequest request) {
         user.updateNickname(request.getNickname());
+        user.updateNotificationTime(request.getNotificationTime());
+        return user;
+    }
+
+    @Override
+    public User updateUserNickname(User user, UserNicknameUpdateRequest request) {
+        user.updateNickname(request.getNickname());
+        return user;
+    }
+
+    @Override
+    public User updateUserNotificationTime(User user, UserNotificationTimeUpdateRequest request) {
         user.updateNotificationTime(request.getNotificationTime());
         return user;
     }

--- a/moodoodle-api/src/main/java/zzangdol/user/presentation/UserController.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/presentation/UserController.java
@@ -19,6 +19,8 @@ import zzangdol.user.domain.User;
 import zzangdol.user.presentation.dto.request.PushNotificationRequest;
 import zzangdol.user.presentation.dto.request.TestPushNotificationRequest;
 import zzangdol.user.presentation.dto.request.UserInfoUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNicknameUpdateRequest;
+import zzangdol.user.presentation.dto.request.UserNotificationTimeUpdateRequest;
 import zzangdol.user.presentation.dto.response.UserInfoResponse;
 
 @RequiredArgsConstructor
@@ -47,6 +49,24 @@ public class UserController {
     @PatchMapping
     public ResponseDto<UserInfoResponse> updateUserInfo(@AuthUser User user, @RequestBody UserInfoUpdateRequest request) {
         return ResponseDto.onSuccess(userFacade.updateUserInfo(user, request));
+    }
+
+    @Operation(
+            summary = "사용자 닉네임 수정 🔑",
+            description = "사용자의 닉네임을 수정합니다."
+    )
+    @PatchMapping("/nickname")
+    public ResponseDto<UserInfoResponse> updateUserNickname(@AuthUser User user, @RequestBody UserNicknameUpdateRequest request) {
+        return ResponseDto.onSuccess(userFacade.updateUserNickname(user, request));
+    }
+
+    @Operation(
+            summary = "사용자 알림 시간 수정 🔑",
+            description = "사용자의 알림 시간을 수정합니다."
+    )
+    @PatchMapping("/notification-time")
+    public ResponseDto<UserInfoResponse> updateUserNotificationTime(@AuthUser User user, @RequestBody UserNotificationTimeUpdateRequest request) {
+        return ResponseDto.onSuccess(userFacade.updateUserNotificationTime(user, request));
     }
 
     @Operation(

--- a/moodoodle-api/src/main/java/zzangdol/user/presentation/dto/request/UserNicknameUpdateRequest.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/presentation/dto/request/UserNicknameUpdateRequest.java
@@ -1,0 +1,18 @@
+package zzangdol.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserNicknameUpdateRequest {
+
+    @Schema(example = "짱짱돌")
+    private String nickname;
+
+}

--- a/moodoodle-api/src/main/java/zzangdol/user/presentation/dto/request/UserNotificationTimeUpdateRequest.java
+++ b/moodoodle-api/src/main/java/zzangdol/user/presentation/dto/request/UserNotificationTimeUpdateRequest.java
@@ -1,0 +1,19 @@
+package zzangdol.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserNotificationTimeUpdateRequest {
+
+    @Schema(example = "20:00")
+    private LocalTime notificationTime;
+
+}


### PR DESCRIPTION
## 🔎 Description
> 회원 정보 수정 API를 분리했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/97](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/97)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
