### PR TITLE
:sparkles: Feature: 기본 카테고리를 우선 정렬하도록 수정

### DIFF
--- a/moodoodle-domain/build.gradle
+++ b/moodoodle-domain/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    implementation project(':moodoodle-common')
+
     // spring boot
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/moodoodle-domain/src/main/java/zzangdol/scrap/dao/querydsl/CategoryQueryRepositoryImpl.java
+++ b/moodoodle-domain/src/main/java/zzangdol/scrap/dao/querydsl/CategoryQueryRepositoryImpl.java
@@ -5,10 +5,12 @@ import static zzangdol.scrap.domain.QCategory.category;
 import static zzangdol.scrap.domain.QScrap.scrap;
 import static zzangdol.scrap.domain.QScrapCategory.scrapCategory;
 
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import zzangdol.constant.Constants;
 import zzangdol.scrap.domain.Category;
 import zzangdol.user.domain.User;
 
@@ -25,7 +27,12 @@ public class CategoryQueryRepositoryImpl implements CategoryQueryRepository {
                 .leftJoin(scrapCategory.scrap, scrap)
                 .where(category.user.eq(user))
                 .groupBy(category.id)
-                .orderBy(scrapCategory.createdAt.max().desc().nullsLast())
+                .orderBy(
+                        new CaseBuilder()
+                                .when(category.name.eq(Constants.DEFAULT_CATEGORY_NAME)).then(0)
+                                .otherwise(1).asc(),
+                        scrapCategory.createdAt.max().desc().nullsLast()
+                )
                 .fetch();
     }
 


### PR DESCRIPTION
## 🔎 Description
> GET
/api/categories [스크랩 탭] 카테고리 목록 조회 🔑 API 에서 기본 카테고리를 우선 정렬하도록 수정했습니다.
- '모든 스크랩' 카테고리를 목록의 맨 앞에 위치시키기 위해 CASE 문을 사용하여 정렬 우선순위 부여
- 나머지 카테고리는 최신 스크랩 생성일을 기준으로 정렬

## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/99](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/99)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
