### PR TITLE
:sparkles: Feature: 일기 이미지 재생성 기능 구현

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/diary/business/DiaryFacade.java
+++ b/moodoodle-api/src/main/java/zzangdol/diary/business/DiaryFacade.java
@@ -14,6 +14,7 @@ import zzangdol.diary.presentation.dto.request.ImageCreateRequest;
 import zzangdol.diary.presentation.dto.response.DiaryListResponse;
 import zzangdol.diary.presentation.dto.response.DiaryResponse;
 import zzangdol.diary.presentation.dto.response.ImageListResponse;
+import zzangdol.diary.presentation.dto.response.ImageResponse;
 import zzangdol.emotion.dao.querydsl.EmotionQueryRepository;
 import zzangdol.emotion.domain.Emotion;
 import zzangdol.scrap.implement.ScrapQueryService;
@@ -38,14 +39,19 @@ public class DiaryFacade {
         return diaryCommandService.createDiary(user, request, color, emotions).getId();
     }
 
-    public ImageListResponse createDiaryImage(User user, ImageCreateRequest request) {
+    public ImageListResponse generateDiaryImage(User user, ImageCreateRequest request) {
 //        List<String> imageUrls = text2ImageModelClient.generateImage(request.getContent());
         List<String> imageUrls = new ArrayList<>();
         imageUrls.add("https://moodoodle-diary-image.s3.ap-northeast-2.amazonaws.com/diary_image_1.png");
         imageUrls.add("https://moodoodle-diary-image.s3.ap-northeast-2.amazonaws.com/diary_image_2.png");
         imageUrls.add("https://moodoodle-diary-image.s3.ap-northeast-2.amazonaws.com/diary_image_3.png");
         imageUrls.add("https://moodoodle-diary-image.s3.ap-northeast-2.amazonaws.com/diary_image_4.png");
-        return DiaryMapper.toImageResponse(imageUrls);
+        return DiaryMapper.toImageListResponse(imageUrls);
+    }
+
+    public ImageResponse regenerateDiaryImage(User user, ImageCreateRequest request) {
+//        String imageUrl = text2ImageModelClient.regenerateImage(request.getContent());
+        return DiaryMapper.toImageResponse("https://moodoodle-diary-image.s3.ap-northeast-2.amazonaws.com/diary_image_1.png");
     }
 
     public Long updateDiary(User user, Long diaryId, DiaryUpdateRequest request) {

--- a/moodoodle-api/src/main/java/zzangdol/diary/business/DiaryMapper.java
+++ b/moodoodle-api/src/main/java/zzangdol/diary/business/DiaryMapper.java
@@ -15,6 +15,7 @@ import zzangdol.diary.presentation.dto.response.DiaryListResponse;
 import zzangdol.diary.presentation.dto.response.DiaryResponse;
 import zzangdol.diary.presentation.dto.response.DiarySummaryResponse;
 import zzangdol.diary.presentation.dto.response.ImageListResponse;
+import zzangdol.diary.presentation.dto.response.ImageResponse;
 import zzangdol.emotion.business.EmotionMapper;
 import zzangdol.emotion.presentation.dto.response.EmotionResponse;
 
@@ -69,9 +70,15 @@ public class DiaryMapper {
                 .build();
     }
 
-    public static ImageListResponse toImageResponse(List<String> imageUrls) {
+    public static ImageListResponse toImageListResponse(List<String> imageUrls) {
         return ImageListResponse.builder()
                 .imageUrls(imageUrls)
+                .build();
+    }
+
+    public static ImageResponse toImageResponse(String imageUrl) {
+        return ImageResponse.builder()
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/moodoodle-api/src/main/java/zzangdol/diary/presentation/DiaryController.java
+++ b/moodoodle-api/src/main/java/zzangdol/diary/presentation/DiaryController.java
@@ -21,6 +21,7 @@ import zzangdol.diary.presentation.dto.request.ImageCreateRequest;
 import zzangdol.diary.presentation.dto.response.DiaryListResponse;
 import zzangdol.diary.presentation.dto.response.DiaryResponse;
 import zzangdol.diary.presentation.dto.response.ImageListResponse;
+import zzangdol.diary.presentation.dto.response.ImageResponse;
 import zzangdol.global.annotation.ApiErrorCodeExample;
 import zzangdol.global.annotation.AuthUser;
 import zzangdol.response.ResponseDto;
@@ -57,8 +58,20 @@ public class DiaryController {
             description = "일기 내용을 사용하여 이미지를 생성합니다. (모델 연동 X)"
     )
     @PostMapping("/images")
-    public ResponseDto<ImageListResponse> createDiaryImage(@AuthUser User user, @Valid @RequestBody ImageCreateRequest request) {
-        return ResponseDto.onSuccess(diaryFacade.createDiaryImage(user, request));
+    public ResponseDto<ImageListResponse> generateDiaryImage(@AuthUser User user, @Valid @RequestBody ImageCreateRequest request) {
+        return ResponseDto.onSuccess(diaryFacade.generateDiaryImage(user, request));
+    }
+
+    @ApiErrorCodeExample({
+            ErrorStatus.INTERNAL_SERVER_ERROR
+    })
+    @Operation(
+            summary = "일기 이미지 재생성 🔑",
+            description = "일기 내용을 사용하여 이미지를 재생성합니다. (모델 연동 X)"
+    )
+    @PostMapping("/images/regenerate")
+    public ResponseDto<ImageResponse> regenerateDiaryImage(@AuthUser User user, @Valid @RequestBody ImageCreateRequest request) {
+        return ResponseDto.onSuccess(diaryFacade.regenerateDiaryImage(user, request));
     }
 
     @ApiErrorCodeExample({

--- a/moodoodle-api/src/main/java/zzangdol/diary/presentation/dto/response/ImageResponse.java
+++ b/moodoodle-api/src/main/java/zzangdol/diary/presentation/dto/response/ImageResponse.java
@@ -1,0 +1,16 @@
+package zzangdol.diary.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageResponse {
+
+    String imageUrl;
+
+}


### PR DESCRIPTION
## 🔎 Description
> 일기 이미지 재생성 기능을 구현했습니다.
모델 연동 전이므로, 응답으로 더미 데이터를 반환하도록 구현했습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/102](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/102)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
