### PR TITLE
:sparkles: Feature: 카테고리 삭제 기능 구현

### DIFF
--- a/moodoodle-api/src/main/java/zzangdol/scrap/business/CategoryFacade.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/business/CategoryFacade.java
@@ -40,4 +40,8 @@ public class CategoryFacade {
         List<Diary> diariesByCategory = categoryQueryService.getDiariesByCategory(user, categoryId);
         return DiaryMapper.toCategoryDiaryListResponse(diariesByCategory);
     }
+
+    public void deleteCategory(User user, Long categoryId) {
+        categoryCommandService.deleteCategory(user, categoryId);
+    }
 }

--- a/moodoodle-api/src/main/java/zzangdol/scrap/implement/CategoryCommandService.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/implement/CategoryCommandService.java
@@ -8,4 +8,6 @@ public interface CategoryCommandService {
 
     Category createCategory(User user, CategoryCreateRequest request);
 
+    void deleteCategory(User user, Long categoryId);
+
 }

--- a/moodoodle-api/src/main/java/zzangdol/scrap/implement/CategoryCommandServiceImpl.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/implement/CategoryCommandServiceImpl.java
@@ -4,6 +4,10 @@ import groovy.util.logging.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zzangdol.constant.Constants;
+import zzangdol.exception.custom.CategoryAccessDeniedException;
+import zzangdol.exception.custom.CategoryNotFoundException;
+import zzangdol.exception.custom.DefaultCategoryAccessDeniedException;
 import zzangdol.scrap.dao.CategoryRepository;
 import zzangdol.scrap.domain.Category;
 import zzangdol.scrap.presentation.dto.request.CategoryCreateRequest;
@@ -21,6 +25,27 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
     public Category createCategory(User user, CategoryCreateRequest request) {
         Category category = buildCategory(request, user);
         return categoryRepository.save(category);
+    }
+
+    @Override
+    public void deleteCategory(User user, Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> CategoryNotFoundException.EXCEPTION);
+        checkCategoryOwnership(user, category);
+        checkDefaultCategory(category);
+        categoryRepository.deleteById(categoryId);
+    }
+
+    private void checkDefaultCategory(Category category) {
+        if (category.getName().equals(Constants.DEFAULT_CATEGORY_NAME)) {
+            throw DefaultCategoryAccessDeniedException.EXCEPTION;
+        }
+    }
+
+    private void checkCategoryOwnership(User user, Category category) {
+        if (!category.getUser().getId().equals(user.getId())) {
+            throw CategoryAccessDeniedException.EXCEPTION;
+        }
     }
 
     private Category buildCategory(CategoryCreateRequest request, User user) {

--- a/moodoodle-api/src/main/java/zzangdol/scrap/presentation/CategoryController.java
+++ b/moodoodle-api/src/main/java/zzangdol/scrap/presentation/CategoryController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,7 +67,8 @@ public class CategoryController {
             description = "사용자의 카테고리 목록을 반환합니다. 카테고리가 존재하지 않으면 빈 리스트를 반환합니다."
     )
     @GetMapping("/scraps")
-    public ResponseDto<ScrapCategoryListResponse> getScrapCategoriesByUser(@AuthUser User user, @RequestParam Long diaryId) {
+    public ResponseDto<ScrapCategoryListResponse> getScrapCategoriesByUser(@AuthUser User user,
+                                                                           @RequestParam Long diaryId) {
         return ResponseDto.onSuccess(categoryFacade.getScrapCategoriesByUser(user, diaryId));
     }
 
@@ -79,8 +81,24 @@ public class CategoryController {
             description = "특정 스크랩 카테고리에 속한 일기 목록을 조회합니다."
     )
     @GetMapping("/{categoryId}/diaries")
-    public ResponseDto<CategoryDiaryListResponse> getDiariesByCategory(@AuthUser User user, @PathVariable("categoryId") Long categoryId) {
+    public ResponseDto<CategoryDiaryListResponse> getDiariesByCategory(@AuthUser User user,
+                                                                       @PathVariable("categoryId") Long categoryId) {
         return ResponseDto.onSuccess(categoryFacade.getDiariesByCategory(user, categoryId));
+    }
+
+    @ApiErrorCodeExample({
+            ErrorStatus.CATEGORY_NOT_FOUND,
+            ErrorStatus.INTERNAL_SERVER_ERROR
+    })
+    @Operation(
+            summary = "카테고리 삭제 🔑",
+            description = "지정된 ID의 카테고리를 삭제합니다. 삭제 성공 시 true를 반환합니다."
+    )
+    @DeleteMapping("/{categoryId}")
+    public ResponseDto<Boolean> deleteCategory(@AuthUser User user,
+                                               @PathVariable("categoryId") Long categoryId) {
+        categoryFacade.deleteCategory(user, categoryId);
+        return ResponseDto.onSuccess(true);
     }
 
 }

--- a/moodoodle-common/src/main/java/zzangdol/exception/custom/CategoryAccessDeniedException.java
+++ b/moodoodle-common/src/main/java/zzangdol/exception/custom/CategoryAccessDeniedException.java
@@ -1,0 +1,18 @@
+package zzangdol.exception.custom;
+
+import zzangdol.exception.GeneralException;
+import zzangdol.response.status.ErrorStatus;
+
+public class CategoryAccessDeniedException extends GeneralException {
+
+    public static final GeneralException EXCEPTION = new CategoryAccessDeniedException();
+
+    public CategoryAccessDeniedException() {
+        super(ErrorStatus.CATEGORY_ACCESS_DENIED);
+    }
+
+    public CategoryAccessDeniedException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+
+}

--- a/moodoodle-common/src/main/java/zzangdol/exception/custom/DefaultCategoryAccessDeniedException.java
+++ b/moodoodle-common/src/main/java/zzangdol/exception/custom/DefaultCategoryAccessDeniedException.java
@@ -1,0 +1,18 @@
+package zzangdol.exception.custom;
+
+import zzangdol.exception.GeneralException;
+import zzangdol.response.status.ErrorStatus;
+
+public class DefaultCategoryAccessDeniedException extends GeneralException {
+
+    public static final GeneralException EXCEPTION = new DefaultCategoryAccessDeniedException();
+
+    public DefaultCategoryAccessDeniedException() {
+        super(ErrorStatus.DEFAULT_CATEGORY_ACCESS_DENIED);
+    }
+
+    public DefaultCategoryAccessDeniedException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+
+}

--- a/moodoodle-common/src/main/java/zzangdol/response/status/ErrorStatus.java
+++ b/moodoodle-common/src/main/java/zzangdol/response/status/ErrorStatus.java
@@ -43,7 +43,9 @@ public enum ErrorStatus implements BaseStatus {
     // Scrap (4200 ~ 4250)
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, 4200, "스크랩이 존재하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4201, "카테고리가 존재하지 않습니다."),
-    SCRAP_DUPLICATION(HttpStatus.CONFLICT, 4202, "해당 사용자와 다이어리에 대해 이미 스크랩이 존재합니다.");
+    SCRAP_DUPLICATION(HttpStatus.CONFLICT, 4202, "해당 사용자와 다이어리에 대해 이미 스크랩이 존재합니다."),
+    CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4203, "카테고리 접근이 거부되었습니다."),
+    DEFAULT_CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4204, "기본 카테고리 접근이 거부되었습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;


### PR DESCRIPTION
## 🔎 Description
> 카테고리 삭제 기능을 구현했습니다.
카테고리의 소유자가 아니거나 기본 카테고리 삭제를 시도하는 경우에 `Access Denied Exception`을 발생시켰습니다.


## 🔗 Related Issue
- [https://github.com/Team-Zzangdol/mooDoodle-backend/issues/104](https://github.com/Team-Zzangdol/mooDoodle-backend/issues/104)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
